### PR TITLE
[WIP] add iclojure support and working metaprob tutorial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # jupyter project recommends pinning the base image: https://github.com/jupyter/docker-stacks#other-tips-and-known-issues
 # jupyter project recently removed support for python2, we'll recreate it using their commit as a guide
 # https://github.com/jupyter/docker-stacks/commit/32b3d2bec23bc46fab1ed324f04a0ad7a7c73747#commitcomment-24129620
-FROM jupyter/minimal-notebook:f9e77e3ddd6f
+FROM jupyter/minimal-notebook:d4cbf2f80a2a
 
 ENV CLOJURE_VERSION 1.10.0.442
+ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
 
 # install conda-build into the root environment. useful for reproducing travis runs.
 # also install java-jdk for clojure notebooks
@@ -52,10 +53,12 @@ RUN chown -R $NB_USER /usr/local/etc/skel/jupyter
 
 USER $NB_USER
 
-# install clojupyter
-RUN git clone https://github.com/roryk/clojupyter /tmp/clojupyter && \
-    cd /tmp/clojupyter && \
-    make && make install
+# install iclojure
+RUN git clone https://github.com/HCADatalab/IClojure /tmp/IClojure && \
+    cd /tmp/IClojure && \
+    make && make install && \
+    jupyter labextension install iclojure_extension && \
+    rm -rf /tmp/IClojure
 
 # bash improvements for developer environment
 RUN git clone --depth=1 https://github.com/Bash-it/bash-it.git ~/.bash_it && \
@@ -78,4 +81,4 @@ COPY files/docker-entrypoint.sh /usr/local/bin/
 ENV PATH $CONDA_DIR/envs/python2/bin:$PATH
 
 ENTRYPOINT      ["tini", "--", "docker-entrypoint.sh"]
-CMD             ["start-notebook.sh"]
+CMD             ["start-notebook.sh", "--NotebookApp.custom_display_url=http://localhost:8888"]

--- a/tutorials/metaprob.ipynb
+++ b/tutorials/metaprob.ipynb
@@ -1,0 +1,80 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully connected!"
+     ]
+    }
+   ],
+   "source": [
+    "/connect -"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[\"/home/iclj/.m2/repository/org/clojure/clojure/1.9.0/clojure-1.9.0.jar\" \"/home/iclj/.m2/repository/org/clojure/core.specs.alpha/0.1.24/core.specs.alpha-0.1.24.jar\" \"/home/iclj/.m2/repository/net/sourceforge/jtransforms/jtransforms/2.4.0/jtransforms-2.4.0.jar\" \"/home/iclj/.m2/repository/redux/redux/0.1.3/redux-0.1.3.jar\" \"/home/iclj/.m2/repository/org/clojure/spec.alpha/0.1.143/spec.alpha-0.1.143.jar\" \"/home/iclj/.m2/repository/org/clojure/tools.cli/0.4.1/tools.cli-0.4.1.jar\" \"/home/iclj/.m2/repository/us/bpsm/edn-java/0.4.6/edn-java-0.4.6.jar\" \"/home/iclj/.m2/repository/net/sourceforge/parallelcolt/optimization/1.0/optimization-1.0.jar\" \"/home/iclj/.m2/repository/net/sourceforge/csparsej/csparsej/1.1.1/csparsej-1.1.1.jar\" \"/home/iclj/.m2/repository/com/googlecode/netlib-java/netlib-java/0.9.3/netlib-java-0.9.3.jar\" \"/home/iclj/.m2/repository/org/clojure/tools.macro/0.1.5/tools.macro-0.1.5.jar\" \"/home/iclj/.m2/repository/incanter/incanter-core/1.9.3/incanter-core-1.9.3.jar\" \"/home/iclj/.m2/repository/net/sourceforge/jplasma/core-lapack/0.1/core-lapack-0.1.jar\" \"/home/iclj/.m2/repository/com/github/rwl/BTFJ/1.0.1/BTFJ-1.0.1.jar\" \"/home/iclj/.m2/repository/com/github/rwl/COLAMDJ/1.0.1/COLAMDJ-1.0.1.jar\" \"/home/iclj/.m2/repository/net/mikera/clojure-utils/0.7.0/clojure-utils-0.7.0.jar\" \"/home/iclj/.m2/repository/com/github/rwl/JKLU/1.0.0/JKLU-1.0.0.jar\" \"/home/iclj/.m2/repository/kixi/stats/0.4.0/stats-0.4.0.jar\" \"/home/iclj/.m2/repository/org/clojure/math.combinatorics/0.1.4/math.combinatorics-0.1.4.jar\" \"/home/iclj/.m2/repository/junit/junit/4.8.2/junit-4.8.2.jar\" \"/home/iclj/.m2/repository/net/mikera/vectorz-clj/0.44.1/vectorz-clj-0.44.1.jar\" \"/home/iclj/.m2/repository/net/mikera/core.matrix/0.52.0/core.matrix-0.52.0.jar\" \"/home/iclj/.m2/repository/net/mikera/mathz/0.3.0/mathz-0.3.0.jar\" \"/home/iclj/.m2/repository/net/sourceforge/jplasma/jplasma/1.2.0/jplasma-1.2.0.jar\" \"/home/iclj/.m2/repository/net/mikera/vectorz/0.62.0/vectorz-0.62.0.jar\" \"/home/iclj/.m2/repository/com/github/rwl/AMDJ/1.0.1/AMDJ-1.0.1.jar\" \"/home/iclj/.m2/repository/net/sourceforge/parallelcolt/parallelcolt/0.10.1/parallelcolt-0.10.1.jar\" \"/home/iclj/.m2/repository/org/clojure/test.check/0.9.0/test.check-0.9.0.jar\" \"/home/iclj/.m2/repository/net/mikera/randomz/0.3.0/randomz-0.3.0.jar\" \"/home/iclj/.m2/repository/net/sourceforge/f2j/arpack_combined_all/0.1/arpack_combined_all-0.1.jar\" \"/home/iclj/.m2/repository/com/tdunning/t-digest/3.2/t-digest-3.2.jar\"] added to the classpath!"
+     ]
+    }
+   ],
+   "source": [
+    "/cp {:deps {probcomp/metaprob {:git/url \"https://github.com/probcomp/metaprob.git\"\n",
+    "                               :sha \"7d40086d486ed452829bce6d8125fbeee691a9a6\"}}}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "Oops",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "Exception while evaluating the expression.",
+      "#unrepl/browsable\n  \u001b[2m[\u001b[22m\u001b[31m#error\u001b[m\n     \u001b[2m{\u001b[22m\u001b[36m:via\u001b[m \u001b[2m[\u001b[22m\u001b[2m{\u001b[22m\u001b[36m:type\u001b[m java.io.FileNotFoundException\u001b[2m,\u001b[22m\n             \u001b[36m:message\u001b[m\n               \"Could not locate metaprob/trace__init.class, metaprob/trace.clj or metaprob/trac\"\u001b[4m/1\u001b[m\u001b[2m,\u001b[22m\n             \u001b[36m:at\u001b[m \u001b[2m[\u001b[22mclojure.lang.RT load \"RT.java\" 466\u001b[2m]\u001b[22m\u001b[2m}\u001b[22m\u001b[2m]\u001b[22m\u001b[2m,\u001b[22m\n      \u001b[36m:trace\u001b[m \u001b[2m[\u001b[22m\u001b[2m[\u001b[22mclojure.lang.RT load \"RT.java\" 466\u001b[2m]\u001b[22m\n              \u001b[2m[\u001b[22mclojure.lang.RT load \"RT.java\" 428\u001b[2m]\u001b[22m\n              \u001b[2m[\u001b[22mclojure.core$load$fn__6824 invoke \"core.clj\" 6126\u001b[2m]\u001b[22m\n              \u001b[2m[\u001b[22mclojure.core$load invokeStatic \"core.clj\" 6125\u001b[2m]\u001b[22m\n              \u001b[2m[\u001b[22mclojure.core$load doInvoke \"core.clj\" 6109\u001b[2m]\u001b[22m\n              \u001b[2m[\u001b[22mclojure.lang.RestFn invoke \"RestFn.java\" 408\u001b[2m]\u001b[22m\n              \u001b[2m[\u001b[22mclojure.core$load_one invokeStatic \"core.clj\" 5908\u001b[2m]\u001b[22m\n              \u001b[2m[\u001b[22mclojure.core$load_one invoke \"core.clj\" 5903\u001b[2m]\u001b[22m\n              \u001b[2m[\u001b[22mclojure.core$load_lib$fn__6765 invoke \"core.clj\" 5948\u001b[2m]\u001b[22m\n              \u001b[2m[\u001b[22mclojure.core$load_lib invokeStatic \"core.clj\" 5947\u001b[2m]\u001b[22m \u001b[4m/2\u001b[m\u001b[2m]\u001b[22m\u001b[2m,\u001b[22m\n      \u001b[36m:cause\u001b[m\n        \"Could not locate metaprob/trace__init.class, metaprob/trace.clj or metaprob/trac\"\u001b[4m/3\u001b[m\u001b[2m}\u001b[22m\n   \u001b[4m/4\u001b[m\u001b[2m]\u001b[22m\n"
+     ]
+    }
+   ],
+   "source": [
+    "(require '[metaprob.trace :as trace])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "IClojure",
+   "language": "iclojure",
+   "name": "iclojure"
+  },
+  "language_info": {
+   "file_extension": ".clj",
+   "mimetype": "text/x-clojure",
+   "name": "clojure",
+   "version": "1.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
included notebook can be tested against `cgrand/iclojure` image with `docker run -p 8888:8888 cgrand/iclojure`

currently blocked on importing metaprob resources. running `(require '[metaprob.trace :as trace])` results in:

```
Exception while evaluating the expression.
#unrepl/browsable
  [#error
     {:via [{:type java.io.FileNotFoundException,
             :message
               "Could not locate metaprob/trace__init.class, metaprob/trace.clj or metaprob/trac"/1,
             :at [clojure.lang.RT load "RT.java" 466]}],
      :trace [[clojure.lang.RT load "RT.java" 466]
              [clojure.lang.RT load "RT.java" 428]
              [clojure.core$load$fn__6824 invoke "core.clj" 6126]
              [clojure.core$load invokeStatic "core.clj" 6125]
              [clojure.core$load doInvoke "core.clj" 6109]
              [clojure.lang.RestFn invoke "RestFn.java" 408]
              [clojure.core$load_one invokeStatic "core.clj" 5908]
              [clojure.core$load_one invoke "core.clj" 5903]
              [clojure.core$load_lib$fn__6765 invoke "core.clj" 5948]
              [clojure.core$load_lib invokeStatic "core.clj" 5947] /2],
      :cause
        "Could not locate metaprob/trace__init.class, metaprob/trace.clj or metaprob/trac"/3}
   /4]
```